### PR TITLE
Fix gitignore to stop watching local database config files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 /node_modules
 yarn-debug.log*
 .yarn-integrity
+
+# Ignore local database settings
+/config/database.yml


### PR DESCRIPTION
Hi,

Here we stop watching DB local configs.