### PR TITLE
Fix webpacker staging env.

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -59,6 +59,16 @@ test:
   # Compile test packs to a separate directory
   public_output_path: packs-test
 
+staging:
+  <<: *default
+
+  # Production depends on precompilation of packs prior to booting for performance.
+  compile: false
+
+  # Cache manifest.json for performance
+  cache_manifest: true
+
+
 production:
   <<: *default
 

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -62,8 +62,7 @@ test:
 staging:
   <<: *default
 
-  # Production depends on precompilation of packs prior to booting for performance.
-  compile: false
+  compile: true
 
   # Cache manifest.json for performance
   cache_manifest: true


### PR DESCRIPTION
Hi,

Heroku was complaining we were missing a `staging` config on webpacker. This PR fixes it.